### PR TITLE
Add MagentoLogger 📝 LoggerUtils ⚙ and AuthenticationError ⛔😲

### DIFF
--- a/magento/__init__.py
+++ b/magento/__init__.py
@@ -6,8 +6,8 @@ from . import utils
 
 Client = clients.Client
 logger = utils.MagentoLogger(
-    name="magento",
-    log_file='magento.log',
+    name=utils.MagentoLogger.PACKAGE_LOG_NAME,
+    log_file=utils.MagentoLogger.PACKAGE_LOG_NAME + '.log',
     stdout_level='WARNING'  # Clients will log to console
 )
 logger.debug('Initialized MyMagento')

--- a/magento/__init__.py
+++ b/magento/__init__.py
@@ -4,9 +4,10 @@ from . import models
 from . import entities
 from . import utils
 
-import logging
-logger = utils.MagentoLogger(name='MyMagento', log_file='magento.log', level=logging.DEBUG)
-
 Client = clients.Client
-
-
+logger = utils.MagentoLogger(
+    name="magento",
+    log_file='magento.log',
+    stdout_level='WARNING'  # Clients will log to console
+)
+logger.debug('Initialized MyMagento')

--- a/magento/__init__.py
+++ b/magento/__init__.py
@@ -5,9 +5,8 @@ from . import entities
 from . import utils
 
 import logging
-logging.basicConfig(filename=f'magento.log', level=logging.DEBUG)
-LOGGER = utils.setup_logger('MyMagento', log_file='magento.log')
-
+logger = utils.MagentoLogger(name='MyMagento', log_file='magento.log', level=logging.DEBUG)
 
 Client = clients.Client
+
 

--- a/magento/__init__.py
+++ b/magento/__init__.py
@@ -4,5 +4,10 @@ from . import models
 from . import entities
 from . import utils
 
-from .clients import Client
+import logging
+logging.basicConfig(filename=f'magento.log', level=logging.DEBUG)
+LOGGER = utils.setup_logger('MyMagento', log_file='magento.log')
+
+
+Client = clients.Client
 

--- a/magento/clients.py
+++ b/magento/clients.py
@@ -166,19 +166,15 @@ class Client(object):
 
     def to_json(self, validate=False) -> str:
         """Validates and saves login credentials for this domain"""
-        data = copy.deepcopy(self.USER_CREDENTIALS)
         if validate:
-            if not self.validate():
-                raise AuthenticationError(
-                    'Failed to validate credentials'
-                )
-        data.update(
-            {  # Add more to this if you want!
-                'domain': self.domain,
-                'user_agent': self.user_agent,
-                'token': self.token
-            }
-        )
+            self.validate()
+        data = {    # Add more to this if you want!
+            'domain': self.domain,
+            'user_agent': self.user_agent,
+            'token': self.token,
+            'log_level': self.logger.logger.level
+        }
+        data.update(self.USER_CREDENTIALS)
         return json.dumps(data)
 
     @classmethod

--- a/magento/clients.py
+++ b/magento/clients.py
@@ -189,22 +189,22 @@ class AuthenticationError(Exception):
     DEFAULT_MSG = 'Failed to authenticate credentials. '
 
     def __init__(self, client: Client, msg=None, response: requests.Response = None):
-        self.msg = msg if msg else AuthenticationError.DEFAULT_MSG
+        self.message = msg if msg else AuthenticationError.DEFAULT_MSG
         self.logger = client.logger
 
-        if response:
+        if response is not None:
             self.parse(response)
 
-        self.logger.error(self.msg)
-        super().__init__(self.msg)
+        self.logger.error(self.message)
+        super().__init__(self.message)
 
     def parse(self, response: requests.Response) -> None:
         """Parses the error message from the response, including message parameters when available"""
-        message = response.json().get('message')
+        msg = response.json().get('message')
         errors = response.json().get('errors')
 
-        if message:
-            self.msg += message + '\n'
+        if msg:
+            self.message += ' ' + '\n' + f'Response: {msg}'
 
         if errors:
             for error in errors:
@@ -215,4 +215,4 @@ class AuthenticationError(Exception):
                     for param in err_params:
                         err_msg = err_msg.replace(f'%{param}', err_params[param])
 
-                self.msg += err_msg + '\n'
+                self.message += err_msg + '\n'

--- a/magento/utils.py
+++ b/magento/utils.py
@@ -1,3 +1,5 @@
+import sys
+import logging
 import requests
 
 
@@ -38,3 +40,33 @@ def get_agents() -> []:
 def get_agent() -> str:
     """Returns a single user agent string"""
     return get_agents()[0]
+
+
+LOG_FORMATTER = logging.Formatter(
+    fmt="%(asctime)s %(levelname)-2s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+
+def setup_logger(name, log_file='', level=logging.INFO):
+    """Configures and returns a logger. Uses existing loggers if possible"""
+    logger = logging.getLogger(name)
+    stdout_name = f'{name}_stdoutLogger'
+    for handler in logger.handlers:
+        if handler.name == stdout_name:
+            return logger
+
+    stdout_handler = logging.StreamHandler(stream=sys.stdout)
+    stdout_handler.setFormatter(LOG_FORMATTER)
+    stdout_handler.name = stdout_name
+
+    if not log_file:
+        log_file = f'{name}.log'
+
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(LOG_FORMATTER)
+
+    logger.setLevel(level)
+    logger.addHandler(stdout_handler)
+    logger.addHandler(file_handler)
+    return logger

--- a/magento/utils.py
+++ b/magento/utils.py
@@ -5,8 +5,8 @@ import requests
 
 class ItemManager:
 
-    def __init__(self):
-        self.items = []
+    def __init__(self, items=None):
+        self.items = items if items else []
 
     def add(self, item):
         if item not in self.items:
@@ -19,29 +19,6 @@ class ItemManager:
         return sum(self.get_attrs(attr))
 
 
-AGENTS = [
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36',
-]
-
-
-def get_agents() -> []:
-    """Scrapes a list of user agents. Returns a default list if the scrape fails."""
-    if (response := requests.get('https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome')).ok:
-        section = response.text.split('<h2>Latest Chrome on Windows 10 User Agents</h2>')[1]
-        raw_agents = section.split('code\">')[1:]
-        agents = [agent.split('<')[0] for agent in raw_agents]
-        for a in agents:
-            if a not in AGENTS:
-                AGENTS.append(a)
-    # If function fails will return the hardcoded list
-    return AGENTS
-
-
-def get_agent() -> str:
-    """Returns a single user agent string"""
-    return get_agents()[0]
-
-
 class MagentoLogger:
 
     FORMATTER = logging.Formatter(
@@ -49,27 +26,33 @@ class MagentoLogger:
         datefmt="%Y-%m-%d %H:%M:%S"
     )
 
-    def __init__(self, name, log_file='', level=logging.INFO):
+    def __init__(self, name, log_file='', stdout_level=logging.INFO):
         """
-        The logger used for this package. Mostly taken from the PyCloudLogger class in my other repo (you should check it out, it's useful 😉)
-        (https://github.com/TDKorn/icloud-photos-to-google-drive/blob/main/pycloud/logger.py)
+        The logger class used for this package. Mostly taken from the PyCloudLogger class in my other repo
+        https://github.com/TDKorn/icloud-photos-to-google-drive/blob/main/pycloud/logger.py
+        > You should check it out, it's useful 😉
 
-        A MagentoLogger instance will be attached to each Client object. Since the same Client object will be passed to all wrapper classes,
-        each user will have all activity logged to their own file
+        A MagentoLogger instance is attached to each Client object. Since the same Client will be passed between all the
+        wrapper classes, each user/domain combination will have its own log that tracks activity across all endpoints
 
-        The package itself also has a MagentoLogger attached, which logs all activity across all Clients (future commit)
+        A package-wide MagentoLogger also exists. It is never explicitly used for logging, though - rather, its FileHandler
+        is added to the MagentoLogger of every Client object, allowing the activity across all users to be logged to a single,
+        consolidated file (called "magento.log") in addition to the individual Client logs.
 
-        :param name:        logger name - for a Client, the default name is "<username>_<domain>"
-        :param log_file:    log file to save logs to - default is "<name>.log"
-        :param level:       logging level for stdout logger; (files are set to DEBUG)
+        NOTE: Log files have their logging level set to DEBUG, but the console logging level is your choice
+
+        :param name:        logger name                         for a Client, the default name is "<username>_<domain>"
+        :param log_file:    log file to save logs to            default is "<name>.log"; package log file is "magento.log"
+        :param stdout_level:logging level for stdout logger     default is logging.INFO
+
         """
         self.name = name
         self.logger = self.setup_logger(
             log_file=log_file,
-            level=level
+            stdout_level=stdout_level
         )
 
-    def setup_logger(self, log_file='', level=logging.DEBUG):
+    def setup_logger(self, log_file='', stdout_level=logging.INFO):
         """Configures and returns a logger. Uses existing loggers if possible"""
         logger = logging.getLogger(self.name)
         stdout_name = f'{self.name}_stdoutLogger'
@@ -78,8 +61,9 @@ class MagentoLogger:
                 return logger
 
         stdout_handler = logging.StreamHandler(stream=sys.stdout)
-        stdout_handler.setFormatter(MagentoLogger.FORMATTER)
         stdout_handler.name = stdout_name
+        stdout_handler.setLevel(stdout_level)
+        stdout_handler.setFormatter(MagentoLogger.FORMATTER)
 
         if not log_file:
             log_file = f'{self.name}.log'
@@ -87,9 +71,13 @@ class MagentoLogger:
         file_handler = logging.FileHandler(log_file)
         file_handler.setFormatter(MagentoLogger.FORMATTER)
 
-        logger.setLevel(level)
+        logger.setLevel(logging.DEBUG)
         logger.addHandler(stdout_handler)
         logger.addHandler(file_handler)
+
+        if self.name != 'MyMagento':
+            logger.addHandler(MagentoLogger.get_package_handler())
+
         return logger
 
     def format_msg(self, msg):
@@ -118,3 +106,31 @@ class MagentoLogger:
             self.format_msg(msg)
         )
 
+    @staticmethod
+    def get_package_handler():
+        """Returns the FileHandler object for writing to the magento.log file"""
+        pkg_handlers = logging.getLogger('MyMagento').handlers
+        for handler in pkg_handlers:
+            if isinstance(handler, logging.FileHandler):
+                return handler
+
+
+AGENTS = ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36']
+
+
+def get_agents() -> []:
+    """Scrapes a list of user agents. Returns a default list if the scrape fails."""
+    if (response := requests.get('https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome')).ok:
+        section = response.text.split('<h2>Latest Chrome on Windows 10 User Agents</h2>')[1]
+        raw_agents = section.split('code\">')[1:]
+        agents = [agent.split('<')[0] for agent in raw_agents]
+        for a in agents:
+            if a not in AGENTS:
+                AGENTS.append(a)
+    # If function fails will return the hardcoded list
+    return AGENTS
+
+
+def get_agent() -> str:
+    """Returns a single user agent string"""
+    return get_agents()[0]

--- a/magento/utils.py
+++ b/magento/utils.py
@@ -2,6 +2,8 @@ import sys
 import logging
 import requests
 
+from typing import Union
+
 
 class ItemManager:
 
@@ -20,7 +22,6 @@ class ItemManager:
 
 
 class MagentoLogger:
-
     PACKAGE_LOG_NAME = "magento"
     CLIENT_LOG_NAME = "{DOMAIN}_{USERNAME}"
     PREFIX = "MyMagento"
@@ -33,20 +34,23 @@ class MagentoLogger:
         datefmt="%Y-%m-%d %H:%M:%S"
     )
 
-    def __init__(self, name, log_file='', stdout_level=logging.INFO):
-        """
-        Logging class used within the package. An instance is attached to every client object.
-        Since the same Client is passed between the wrapper classes, each username/domain combination will have its own
-        logger, which will log its activity across all endpoints.
+    def __init__(self, name: str, log_file: str = '', stdout_level: Union[int, str] = 'INFO'):
+        """Logging class used within the package. An instance is attached to every Client upon object initialization.
 
-        Each Client also logs to the consolidated "magento.log" file.
+        Currently, a single Client object is created for each username/domain combination, and this same Client object
+        is passed between all wrapper classes in the package. Since a logger/log file is uniquely associated with a
+        particular user, this allows all activity, across all endpoints, to be logged every time that user logs in
+        (Please don't be creepy with that)
+        All activity from the package, regardless of user, will be logged to the central "magento.log" package log file
 
-        NOTE: Log files have their logging level set to DEBUG, but the console logging level is your choice
+        NOTE: Logging level for stdout logging can be set (default is "INFO") but log files are forced to use "DEBUG"
 
-        :param name:            logger name                         for a Client, the default name is "<username>_<domain>"
-        :param log_file:        log file to save logs to            default is "<name>.log"; package log file is "magento.log"
-        :param stdout_level:    logging level for stdout logger     default is logging.INFO
+        :param name: logger name
+            :var MagentoLogger.CLIENT_LOG_NAME:  the default client logger name
+            :var MagentoLogger.PACKAGE_LOG_NAME: the default package logger name
 
+        :param log_file: log file name; default is {name}.log
+        :param stdout_level: logging level for stdout logger; default is "INFO" (which is also logging.INFO and 10)
         """
         self.name = name
         self.logger = self.setup_logger(
@@ -54,7 +58,7 @@ class MagentoLogger:
             stdout_level=stdout_level
         )
 
-    def setup_logger(self, log_file='', stdout_level=logging.INFO):
+    def setup_logger(self, log_file: str = '', stdout_level: Union[int, str] = 'INFO'):
         """Configures and returns a logger. Uses existing loggers if possible"""
         logger = logging.getLogger(self.name)
         stdout_name = f'{self.name}_stdoutLogger'
@@ -77,50 +81,66 @@ class MagentoLogger:
         logger.addHandler(stdout_handler)
         logger.addHandler(file_handler)
 
+        MagentoLogger.add_request_logging(file_handler)
+
         if self.name != MagentoLogger.PACKAGE_LOG_NAME:
             logger.addHandler(MagentoLogger.get_package_handler())
 
         return logger
 
-    def format_msg(self, msg):
+    def format_msg(self, msg: str) -> str:
+        """Formats MagentoLogger.LOG_MESSAGE using the specified message"""
         return MagentoLogger.LOG_MESSAGE.format(
             name=self.name,
             message=msg
         )
 
     def info(self, msg):
+        """Formats MagentoLogger.LOG_MESSAGE with the specified message, then logs it with Logger.info()"""
         return self.logger.info(
             self.format_msg(msg)
         )
 
     def debug(self, msg):
+        """Formats MagentoLogger.LOG_MESSAGE with the specified message, then logs it with Logger.debug()"""
         return self.logger.debug(
             self.format_msg(msg)
         )
 
-    def warning(self, msg):
-        return self.logger.warning(
-            self.format_msg(msg)
-        )
-
     def error(self, msg):
+        """Formats MagentoLogger.LOG_MESSAGE with the specified message, then logs it with Logger.error()"""
         return self.logger.error(
             self.format_msg(msg)
         )
 
+    def warning(self, msg):
+        """Formats MagentoLogger.LOG_MESSAGE with the specified message, then logs it with Logger.warning()"""
+        return self.logger.warning(
+            self.format_msg(msg)
+        )
+
     @staticmethod
-    def get_package_handler():
+    def get_package_handler() -> logging.FileHandler:
         """Returns the FileHandler object that writes to the magento.log file"""
         pkg_handlers = logging.getLogger(MagentoLogger.PACKAGE_LOG_NAME).handlers
         for handler in pkg_handlers:
             if isinstance(handler, logging.FileHandler):
                 return handler
 
+    @staticmethod
+    def add_request_logging(handler: Union[logging.FileHandler, logging.StreamHandler]):
+        """Adds the specified handler to the requests package logger, allowing for easier debugging of API calls"""
+        req_logger = logging.getLogger('urllib3.connectionpool')
+        req_logger.setLevel(logging.DEBUG)
+        if handler not in req_logger.handlers:
+            req_logger.addHandler(handler)
+
+
 
 AGENTS = ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36']
 
 
-def get_agents() -> []:
+def get_agents() -> list:
     """Scrapes a list of user agents. Returns a default list if the scrape fails."""
     if (response := requests.get('https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome')).ok:
         section = response.text.split('<h2>Latest Chrome on Windows 10 User Agents</h2>')[1]

--- a/magento/utils.py
+++ b/magento/utils.py
@@ -61,9 +61,9 @@ class MagentoLogger:
                 return logger
 
         stdout_handler = logging.StreamHandler(stream=sys.stdout)
-        stdout_handler.name = stdout_name
-        stdout_handler.setLevel(stdout_level)
         stdout_handler.setFormatter(MagentoLogger.FORMATTER)
+        stdout_handler.setLevel(stdout_level)
+        stdout_handler.name = stdout_name
 
         if not log_file:
             log_file = f'{self.name}.log'
@@ -72,8 +72,8 @@ class MagentoLogger:
         file_handler.setFormatter(MagentoLogger.FORMATTER)
 
         logger.setLevel(logging.DEBUG)
-        logger.addHandler(stdout_handler)
         logger.addHandler(file_handler)
+        logger.addHandler(stdout_handler)
 
         if self.name != 'MyMagento':
             logger.addHandler(MagentoLogger.get_package_handler())

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import logging
+
+from magento.utils import MagentoLogger
+from magento.clients import Client, AuthenticationError
+
+DOMAIN = 'website.com'
+USERNAME = 'username'
+PASSWORD = 'password'
+
+logger = MagentoLogger(
+    name='logger_test',
+    log_file='logger_test.log',
+    stdout_level='DEBUG'
+)
+logger.debug('Beginning logger test')
+logger.debug('Logging in to client...')
+try:
+    api = Client(
+        domain=DOMAIN,
+        username=USERNAME,
+        password=PASSWORD
+    )
+    api.logger.debug('Logged in from {}'.format(
+        os.path.abspath('logger_test.py'))
+    )
+    logger.debug('Client logged in.')
+
+except AuthenticationError as e:
+    logger.error(e)
+    logger.debug('Failed to authenticate credentials. Test requires login.')
+    sys.exit(-1)
+
+logger.debug('Verifying correct logger is returned from logger attribute and get_logger() method...')
+attr = api.logger.logger
+meth = api.get_logger().logger
+assert attr == meth
+
+logger.debug('Checking handlers...')
+handlers = [h for h in attr.handlers]
+assert len(handlers) < 4
+
+logger.debug('Checking file handlers...')
+f_handlers = [f for f in handlers if isinstance(f, logging.FileHandler)]
+assert len(f_handlers) == 2
+f1, f2 = f_handlers
+
+
+def fname_from_handler(f_handler):
+    return os.path.basename(f_handler.baseFilename)
+
+
+logger.debug('Checking log files...')
+magento_log = MagentoLogger.PACKAGE_LOG_NAME + '.log'
+client_log = MagentoLogger.CLIENT_LOG_NAME.format(
+    DOMAIN=DOMAIN.split('.')[0],
+    USERNAME=USERNAME
+) + '.log'
+
+assert magento_log in map(fname_from_handler, [f1, f2])
+assert client_log in map(fname_from_handler, [f1, f2])
+logger.debug('All tests passed')
+sys.exit(0)

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -2,65 +2,225 @@ import os
 import sys
 import logging
 
-from magento.utils import MagentoLogger
+import magento
+from magento.utils import MagentoLogger, LoggerUtils
 from magento.clients import Client, AuthenticationError
 
 DOMAIN = 'website.com'
 USERNAME = 'username'
 PASSWORD = 'password'
 
-logger = MagentoLogger(
-    name='logger_test',
-    log_file='logger_test.log',
-    stdout_level='DEBUG'
+PKG_LOG_NAME = MagentoLogger.PACKAGE_LOG_NAME
+PKG_LOG_FILE = PKG_LOG_NAME + '.log'
+PKG_LOG_PATH = os.path.abspath(PKG_LOG_FILE)
+
+PKG_HANDLER = MagentoLogger.get_package_handler()
+PKG_HANDLER_NAME = '{}__{}__{}'.format(
+    MagentoLogger.PREFIX, MagentoLogger.PACKAGE_LOG_NAME, "WARNING"
 )
 
-logger.debug('Beginning logger test')
-logger.debug('Logging in to client...')
-try:
-    api = Client(
-        domain=DOMAIN,
-        username=USERNAME,
-        password=PASSWORD
+
+def test_package_logger():
+    logger.debug('Verifying package log file configuration...')
+    pkg_logger = magento.logger
+    pkg_log_files = LoggerUtils.get_log_files(pkg_logger)
+
+    assert pkg_logger.name == PKG_LOG_NAME
+    assert pkg_logger.log_file == PKG_LOG_FILE
+    assert PKG_LOG_PATH in pkg_log_files
+    assert os.path.exists(PKG_LOG_PATH)
+
+    assert PKG_HANDLER in pkg_logger.handlers
+    assert PKG_HANDLER.name == PKG_HANDLER_NAME
+    assert PKG_HANDLER.baseFilename == PKG_LOG_PATH
+    assert PKG_HANDLER.baseFilename in pkg_logger.log_files
+    logger.debug('Package FileHandler is configured correctly')
+
+    logger.debug('Verifying Package logger stdout configuration...')
+    pkg_stream_handlers = LoggerUtils.get_stream_handlers(pkg_logger)
+    assert len(pkg_stream_handlers) == 1  # Unsure about her...
+    assert pkg_stream_handlers[0].level == logging.WARNING
+    assert pkg_stream_handlers[0].name == PKG_HANDLER_NAME
+    logger.debug('Package StreamHandler is configured correctly')
+
+
+def test_client_logger_access(client: Client):
+    """Test to make sure the Client attribute and method return the same object
+
+    NOTE:
+    client.logger -> MagentoLogger
+    client.logger.logger -> logging.Logger
+    """
+    logger.debug('Verifying correct logger is returned from logger attribute and get_logger() method...')
+    attr = client.logger.logger
+    meth = client.get_logger().logger
+    assert attr == meth
+    logger.debug('Logger access is correct')
+    return True
+
+
+def test_client_logger_file_handlers(client: Client, log_file: str = None):
+    logger.debug('Verifying client log file configuration...')
+    client_logger = client.logger
+    client_name = MagentoLogger.CLIENT_LOG_NAME.format(
+        domain=client.domain.split('.')[0],
+        username=client.USER_CREDENTIALS['username']
+    )
+    client_log_file = log_file if log_file else f'{client_name}.log'
+    client_log_path = os.path.abspath(client_log_file)
+
+    assert client_logger.name == client_name
+    assert client_logger.log_file == client_log_file
+    assert client_logger.log_path == client_log_path
+
+    assert os.path.exists(client_logger.log_path)
+    assert client_logger.log_path in client_logger.log_files
+
+    logger.debug('Client log files are configured correctly')
+    logger.debug('Verifying package handler is added to Client...')
+
+    assert os.path.exists(PKG_LOG_PATH)
+    assert PKG_LOG_PATH in client_logger.log_files  # Pkg logger added to all clients
+
+    assert PKG_HANDLER in client_logger.handlers
+    assert PKG_HANDLER.baseFilename in client_logger.log_files
+
+    logger.debug('Log file configuration is correct')
+    return True
+
+
+def test_client_logger_stream_handlers(client: Client):
+    logger.debug('Verifying client stdout configuration...')
+    client_logger = client.logger
+    client_name = MagentoLogger.CLIENT_LOG_NAME.format(
+        domain=client.domain.split('.')[0],
+        username=client.USER_CREDENTIALS['username']
+    )
+    client_stream_handlers = LoggerUtils.get_stream_handlers(client_logger)
+
+    assert len(client_stream_handlers) == 1  # Should just be Client handler
+
+    stream_handler_name = MagentoLogger.HANDLER_NAME.format(name=client_name, stdout_level="INFO")  # Default level
+    stream_handler = client_stream_handlers[0]
+
+    assert stream_handler.name == stream_handler_name
+    assert stream_handler.level == logging.INFO
+
+    logger.debug('Default stdout configuration is correct')
+    logger.debug('Reconfiguring logger to use DEBUG stdout log level...')
+
+    client_logger.setup_logger(stdout_level='DEBUG')
+    client_stream_handlers = LoggerUtils.get_stream_handlers(client_logger)
+    stream_handler_name = MagentoLogger.HANDLER_NAME.format(name=client_name, stdout_level="DEBUG")
+
+    assert len(client_stream_handlers) == 1
+    assert client_stream_handlers[0].level == logging.DEBUG
+    assert client_stream_handlers[0].name == stream_handler_name
+
+    logger.debug('Client logger level changed to DEBUG. Logging from Client...')
+    client_logger.debug('If you can see this, log level was changed successfully')
+    logger.debug("Changing client logger level back to INFO")
+
+    client_logger.setup_logger(stdout_level="INFO")
+    client_stream_handlers = LoggerUtils.get_stream_handlers(client_logger)
+    stream_handler_name = stream_handler_name.replace("DEBUG", "INFO")  # From above
+
+    assert len(client_stream_handlers) == 1
+    assert client_stream_handlers[0].level == logging.INFO
+    assert client_stream_handlers[0].name == stream_handler_name
+
+    logger.debug('stdout log configuration is correct')
+    return True
+
+
+def test_log_file_change(client: Client):
+    logger.debug('Verifying log file changes are accounted for...')
+    client_logger = client.logger
+    client_log_file_og = client_logger.log_file
+    client_log_path_og = client_logger.log_path
+
+    logger.debug(f'Current Log File: {client_log_file_og}')
+
+    client_log_file_new = 'test_' + client_log_file_og
+    client_logger.log_file = client_log_file_new
+
+    logger.debug(f'Changed log file for client to {client_logger.log_file}')
+    logger.debug('Setting up logger...')
+
+    old_level = LoggerUtils.get_stream_handlers(client_logger)[0].name.split("__")[-1]  # StreamHandler.name = {}__{}__{stdout_level}
+    client_logger.setup_logger(stdout_level=old_level)
+
+    logger.debug(f'New logger set up. Should still be {old_level} for stdout, and writing only to the new log file')
+    logger.debug('Verfying stdout configuration...')
+
+    client_stream_handlers = LoggerUtils.get_stream_handlers(client_logger)
+
+    assert len(client_stream_handlers) == 1
+    assert client_stream_handlers[0].level == logging.getLevelName(old_level)
+
+    logger.debug('Stdout configuration as expected.')
+    logger.debug('Checking log file configuration...')
+
+    if test_client_logger_file_handlers(client, client_log_file_new):
+        logger.debug('New FileHandler set up correctly')
+
+    logger.debug('Making sure old FileHandler is fully removed...')
+
+    client_log_files = LoggerUtils.get_log_files(client_logger)
+    magento_handlers = MagentoLogger.get_magento_handlers(client_logger)
+
+    assert client_log_path_og not in client_log_files  # The old log file
+    assert LoggerUtils.get_handler_by_log_file(client_logger, client_log_file_og) is None  # Handler should be removed too
+    assert len([handler for handler in magento_handlers if isinstance(handler, logging.FileHandler)]) == 2
+    logger.debug('Old FileHandler is fully removed')
+
+
+def test_for_requests_logger(client: Client):
+    import requests
+
+    requests_logger = requests.urllib3.connectionpool.log
+    requests_log_files = LoggerUtils.get_log_files(requests_logger)
+
+    assert PKG_LOG_PATH in requests_log_files
+    assert client.logger.log_path in requests_log_files
+    logger.debug('The requests package logger is writing to both the Client and package log files')
+
+
+if __name__ == '__main__':
+    logger = MagentoLogger(
+        name='logger_test',
+        log_file='logger_test.log',
+        stdout_level='DEBUG'
     )
 
-except AuthenticationError as e:
-    logger.info('Failed to obtain an access token. Please ensure your credentials are corred')
-    sys.exit(-1)
+    logger.debug('Beginning logger test')
+    test_package_logger()
 
-logger.debug('Client logged in.')
-api.logger.debug('Using Client logger to log to {}'.format(__file__))  # Is that a weird test...?
+    logger.debug('Switching to Client logger for remaining tests...')
 
-logger.debug('Verifying correct logger is returned from logger attribute and get_logger() method...')
-attr = api.logger.logger
-meth = api.get_logger().logger
-assert attr == meth
+    client = Client(
+        domain=DOMAIN,
+        username=USERNAME,
+        password=PASSWORD,
+        login=False
+    )
 
-logger.debug('Verifying magento and Client log FileHandlers are present...')
-magento_log = MagentoLogger.PACKAGE_LOG_NAME + '.log'
-client_log = MagentoLogger.CLIENT_LOG_NAME.format(
-    DOMAIN=DOMAIN.split('.')[0],
-    USERNAME=USERNAME) + '.log'
+    logger.debug('Logging in to client...')
 
+    try:
+        client.authenticate()
+        logger.debug('Client logged in')
+        client.logger.info('Hello')  # Client loggers are set to "INFO" for console by default
 
-def get_filehandlers(logger: logging.Logger):
-    """Get all the FileHandlers handling a logger"""
-    return [handler for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+    except AuthenticationError as e:
+        logger.info('Failed to obtain an access token. Please ensure your credentials are correct')
+        sys.exit(-1)
 
+    test_client_logger_access(client)
+    test_client_logger_file_handlers(client)
+    test_client_logger_stream_handlers(client)
+    test_log_file_change(client)
+    test_for_requests_logger(client)
 
-def get_logfiles(logger):
-    """Get the log file paths from all FileHandlers of a logger"""
-    return [handler.baseFilename for handler in get_filehandlers(logger)]
-
-
-assert os.path.abspath(magento_log) in get_logfiles(api.logger.logger)
-assert os.path.abspath(client_log) in get_logfiles(api.logger.logger)
-logger.debug('The Client is writing to both the Client and package log files ')
-
-requests_logger = logging.getLogger('urllib3.connectionpool')
-assert os.path.abspath(magento_log) in get_logfiles(requests_logger)
-assert os.path.abspath(client_log) in get_logfiles(requests_logger)
-logger.debug('The requests package logger is writing to both the Client and package log files')
-
-logger.debug('All tests passed')
-sys.exit(0)
+    logger.debug('All tests passed')
+    sys.exit(0)

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -14,6 +14,7 @@ logger = MagentoLogger(
     log_file='logger_test.log',
     stdout_level='DEBUG'
 )
+
 logger.debug('Beginning logger test')
 logger.debug('Logging in to client...')
 try:
@@ -22,43 +23,44 @@ try:
         username=USERNAME,
         password=PASSWORD
     )
-    api.logger.debug('Logged in from {}'.format(
-        os.path.abspath('logger_test.py'))
-    )
-    logger.debug('Client logged in.')
 
 except AuthenticationError as e:
-    logger.error(e)
-    logger.debug('Failed to authenticate credentials. Test requires login.')
+    logger.info('Failed to obtain an access token. Please ensure your credentials are corred')
     sys.exit(-1)
+
+logger.debug('Client logged in.')
+api.logger.debug('Using Client logger to log to {}'.format(__file__))  # Is that a weird test...?
 
 logger.debug('Verifying correct logger is returned from logger attribute and get_logger() method...')
 attr = api.logger.logger
 meth = api.get_logger().logger
 assert attr == meth
 
-logger.debug('Checking handlers...')
-handlers = [h for h in attr.handlers]
-assert len(handlers) < 4
-
-logger.debug('Checking file handlers...')
-f_handlers = [f for f in handlers if isinstance(f, logging.FileHandler)]
-assert len(f_handlers) == 2
-f1, f2 = f_handlers
-
-
-def fname_from_handler(f_handler):
-    return os.path.basename(f_handler.baseFilename)
-
-
-logger.debug('Checking log files...')
+logger.debug('Verifying magento and Client log FileHandlers are present...')
 magento_log = MagentoLogger.PACKAGE_LOG_NAME + '.log'
 client_log = MagentoLogger.CLIENT_LOG_NAME.format(
     DOMAIN=DOMAIN.split('.')[0],
-    USERNAME=USERNAME
-) + '.log'
+    USERNAME=USERNAME) + '.log'
 
-assert magento_log in map(fname_from_handler, [f1, f2])
-assert client_log in map(fname_from_handler, [f1, f2])
+
+def get_filehandlers(logger: logging.Logger):
+    """Get all the FileHandlers handling a logger"""
+    return [handler for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+
+
+def get_logfiles(logger):
+    """Get the log file paths from all FileHandlers of a logger"""
+    return [handler.baseFilename for handler in get_filehandlers(logger)]
+
+
+assert os.path.abspath(magento_log) in get_logfiles(api.logger.logger)
+assert os.path.abspath(client_log) in get_logfiles(api.logger.logger)
+logger.debug('The Client is writing to both the Client and package log files ')
+
+requests_logger = logging.getLogger('urllib3.connectionpool')
+assert os.path.abspath(magento_log) in get_logfiles(requests_logger)
+assert os.path.abspath(client_log) in get_logfiles(requests_logger)
+logger.debug('The requests package logger is writing to both the Client and package log files')
+
 logger.debug('All tests passed')
 sys.exit(0)


### PR DESCRIPTION
# 🌟Feature Update  -  Add Logging and (Better) Exceptions🌟

Logging and exceptions - can you think of anything more exciting? 😩
- How about writing these long messages to inform the 0 people using this repo of the changes? 😍🤩😍


## Major Changes 

- Add logging support to the package through `MagentoLogger`,  a new custom logging class for this package
- Update the `AuthenticationError` class to be more than just `pass`
- Added a `tests` folder and added `logger_test.py` to it

## MagentoLogger

### Summary (TL;DR)
1. It's a custom logging class for the package that can be used like any other logger
2. It has custom log message formatting and a bunch of extra helper methods (and static methods) built in

You can create a ```MagentoLogger``` from scratch, or you can call it from the package or a ```Client```

```python
# Use Client Logger
from magento import Client

>>> api = Client('website.com','username', 'password', login=False)
>>> api.logger.info('Hello from Client')

2022-06-17 00:18:07 INFO   |[ MyMagento | website_username ]|:  Hello from Client
```
***
```python
# Use Package Logger
import magento
>>> magento.logger.info("Hello from my-magento")  # stdout_level is WARNING for package logger


>>> magento.logger.warning("Hello from my-magento")  

2022-06-17 00:16:06 WARNING  |[ MyMagento | my-magento ]|:  Hello from my-magento
```
***
```python
# Create from scratch
from magento.utils import MagentoLogger    

>>> logger = MagentoLogger('magento_logger')
>>> logger.info('Hello')

2022-06-16 23:54:38 INFO   |[ MyMagento | magento_logger ]|:  Hello

>>> print(logger.handler_map)  # One of the many helper methods; maps handlers of a logger by type and name

{  
    'stream': {'MyMagento__magento_logger__INFO': <StreamHandler <stdout> (INFO)>},  # Default level is INFO
    'file': {  # FileHandlers are set to DEBUG; all handler names are based off stdout_level
        'MyMagento__magento_logger__INFO': { 
            'handler': <FileHandler C:\path\to\my-magento\magento_logger.log (DEBUG)>,
            'file': 'C:\\path\\to\\my-magento\\magento_logger.log'
        },
        'MyMagento__my-magento__WARNING': {  # Handler for the package, added to every MagentoLogger; stdout_level is WARNING 
            'handler': <FileHandler C:\path\to\my-magento\my-magento.log (DEBUG)>,
            'file': 'C:\\path\\to\\my-magento\\my-magento.log'
        }
    }
}
```
***
### Important Info/Actual Details
- Each ```Client``` object logs to its own log file as well as a central log file
  - A ```MagentoLogger``` instance is attached to each ```Client``` object at the time of its initialization
  - Each ```MagentoLogger``` is associated with a client using its unique ```domain```/```username``` combination 
-  Access a `Client` logger via ```Client.logger``` or ```Client.get_logger()```
    - Note that ```get_logger()``` will return a new ```MagentoLogger``` instance but it does NOT automatically update the ```Client``` with the new logger
      - Meant to be a shortcut to quickly make a new one based off the ```Client```, since the ```domain```/```username``` combination is used to configure the logger/log files
    - Use ```Client.logger.setup_logger()``` to modify in place


```python
from magento import Client

>>> api = Client('domain.com', 'username', 'password')

# Default Stdout Level is INFO
>>> api.logger.debug("AYOOO")


# Log level can be changed in place though
>>> api.logger.setup_logger(stdout_level="DEBUG")

True

# Or create and assign a new MagentoLogger object
api.logger = api.get_logger(stdout_level="DEBUG")

# Verify it worked
api.logger.debug("AYOOO")
>>> 2022-06-15 23:01:17 DEBUG  |[ MyMagento | domain_username ]|:  AYOOO
```

- Currently the package log file is ```my-magento.log```  but it depends on the value of ```MagentoLogger.PACKAGE_LOG_NAME```
    - Regardless of the name, you can call ```MagentoLogger.get_package_handler()``` to retrieve the FileHandler that writes to it
- The log level for console logging can be set with the ```stdout_level``` param, but all log files are written to with ```DEBUG```

***

### MagentoLogger Class Variables
You can use/edit the class variables below to change how names, messages, etc. look and function. Why class variables?

1) They can be accessed easily for formatting outside the class
2) They can be used for name checking outside the class
3) They can still reliably and effortlessly (!!!) do both of the above whenever I change formats

Using the class variables means only the variables themselves will need to be changed to make package-wide updates

```python
class MagentoLogger:
    """Logging class used within the package

    :cvar PREFIX:           hardcoded prefix to use in log messages
    :cvar PACKAGE_LOG_NAME: the default name for the package logger
    :cvar CLIENT_LOG_NAME:  the default format for the client logger name
    :cvar LOG_MESSAGE:      the default format for the message component of log messages.
                            (Use magento.logger.LOG_MESSAGE for easy access)
    :cvar FORMATTER:        the default logging format
    :type FORMATTER:        logging.Formatter
    :cvar HANDLER_NAME      the default format for the names of handlers created by this package
    """

    PREFIX = "MyMagento"
    PACKAGE_LOG_NAME = "my-magento"
    CLIENT_LOG_NAME = "{domain}_{username}"
    HANDLER_NAME = '{}__{}__{}'.format(PREFIX, '{name}', '{stdout_level}')
    
    LOG_MESSAGE = "|[ {pfx} | {name} ]|:  {message}".format(
            pfx=PREFIX, name="{name}", message="{message}"
     )
    
     FORMATTER = logging.Formatter(
            fmt="%(asctime)s %(levelname)-5s  %(message)s",
            datefmt="%Y-%m-%d %H:%M:%S"
     )
```

***



## AuthenticationError
 - Update ```AuthenticationError``` class to accept a ```Client``` and ```response``` as parameters
   - ```Client``` is used solely for its logger
   - ```response``` is the response that led to the exception being raised. 
 - If a ```response``` is provided, ```parse()``` adds to the exception/log message from the response body
 -  Once a exception message is built, it is logged using the ```Client```'s ```MagentoLogger``` before being raised
 -  Written specifically for token auth errors, but should be flexible enough to handle most bad API responses

## Client
* Added ```get_logger()```  method and  ```logger```  instance attribute
* Added ```log_level``` parameter to ```__init__()``` to set console log level (default is "INFO")
* Updated ```validate()``` and ```authenticate()```  methods to make use of the logger.
* Update ```validate()``` to raise an ```AuthenticationError``` if it fails now
  - Every method did that after checking anyways so like? Why not
* Updated ```to_pickle() 🥒``` and ```to_json()``` to not raise ```AuthenticationError``` after calling ```validate()```
  * ```to_json()``` also includes ```log_level``` key now so full settings can be loaded
* Changed ```authenticate()``` to catch the ```AuthenticationError``` raised by ```validate()```, then raise another ```AuthenticationError``` from it
  - Indicates that the token request was successful, but the validation failed... could be helpful for debugging without checking logs?
* Add type/return hints to help with the next step in this repo: documentation 😍😍(😭)